### PR TITLE
Security: Implement fail-fast secret validation at startup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -515,9 +515,9 @@ A comprehensive security review was conducted on 2025-12-28 (see `docs/ai-counci
 - [x] OAuth state validation (server-side) - `backend/oauth_state.py`
 - [x] PKCE implementation for Google OAuth (S256 code challenge)
 - [x] Frontend strict state validation (fail hard on mismatch)
+- [x] Fail-fast secret validation at startup - `backend/config.py:validate_secrets()`
 
 **Remaining items before launch:**
-- [ ] Fail-fast secret validation at startup
 - [ ] Complete database migrations for all tables
 - [ ] Rate limiting and request size limits
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,9 +1,13 @@
 """Configuration for the LLM Council."""
 
 import os
+import logging
 from dotenv import load_dotenv
 
 load_dotenv()
+
+# Production detection - Fly.io sets FLY_APP_NAME, can also check DATABASE_URL
+IS_PRODUCTION = os.getenv("FLY_APP_NAME") is not None or os.getenv("PRODUCTION") == "true"
 
 # OpenRouter API key (fallback for local dev, users provide their own in production)
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
@@ -42,3 +46,63 @@ DEFAULT_LEAD_MODEL = "google/gemini-3-pro-preview"
 
 # OpenRouter API endpoint
 OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+
+def validate_secrets() -> None:
+    """Validate that required secrets are configured.
+
+    In production, this function ensures all security-critical environment
+    variables are properly set. Raises RuntimeError if validation fails,
+    causing the application to fail fast at startup.
+
+    In development (IS_PRODUCTION=False), only warnings are logged.
+    """
+    logger = logging.getLogger(__name__)
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    # JWT secret validation
+    if JWT_SECRET == "change-me-in-production":
+        if IS_PRODUCTION:
+            errors.append("JWT_SECRET must be set to a secure value in production")
+        else:
+            warnings.append("JWT_SECRET is using default value (ok for local dev)")
+
+    # API key encryption validation
+    if not API_KEY_ENCRYPTION_KEY:
+        if IS_PRODUCTION:
+            errors.append(
+                "API_KEY_ENCRYPTION_KEY must be set in production. "
+                "Generate with: python -c \"from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())\""
+            )
+        else:
+            warnings.append("API_KEY_ENCRYPTION_KEY not set (API key storage disabled)")
+
+    # OAuth credentials validation
+    if not GOOGLE_CLIENT_ID or not GOOGLE_CLIENT_SECRET:
+        if IS_PRODUCTION:
+            errors.append("Google OAuth credentials (GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET) must be set in production")
+        else:
+            warnings.append("Google OAuth credentials not set (Google login disabled)")
+
+    if not GITHUB_CLIENT_ID or not GITHUB_CLIENT_SECRET:
+        if IS_PRODUCTION:
+            errors.append("GitHub OAuth credentials (GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET) must be set in production")
+        else:
+            warnings.append("GitHub OAuth credentials not set (GitHub login disabled)")
+
+    # Database validation (required for production)
+    if not DATABASE_URL:
+        if IS_PRODUCTION:
+            errors.append("DATABASE_URL must be set in production")
+        # In dev, we fall back to local JSON storage - no warning needed
+
+    # Log warnings
+    for warning in warnings:
+        logger.warning(warning)
+
+    # Fail fast on errors
+    if errors:
+        error_msg = "Configuration errors detected:\n" + "\n".join(f"  - {e}" for e in errors)
+        logger.error(error_msg)
+        raise RuntimeError(error_msg)

--- a/backend/main.py
+++ b/backend/main.py
@@ -16,7 +16,8 @@ from .config import (
     DATABASE_URL,
     AVAILABLE_MODELS,
     DEFAULT_MODELS,
-    DEFAULT_LEAD_MODEL
+    DEFAULT_LEAD_MODEL,
+    validate_secrets
 )
 from .auth_jwt import (
     get_current_user,
@@ -60,6 +61,9 @@ else:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Manage application lifecycle - startup and shutdown events."""
+    # Fail fast if required secrets are not configured
+    validate_secrets()
+
     if not USE_LOCAL_STORAGE:
         # Startup: initialize database pool
         await get_pool()

--- a/docs/IMPLEMENTATION_PLAN_security_fixes.md
+++ b/docs/IMPLEMENTATION_PLAN_security_fixes.md
@@ -12,7 +12,7 @@
 | Phase | Item | Status | PR |
 |-------|------|--------|-----|
 | 1.1 | OAuth State Validation & PKCE | ✅ Complete | [#16](https://github.com/anbuneel/ai-council/pull/16) |
-| 1.2 | Fail-Fast Secret Validation | ⏳ Pending | - |
+| 1.2 | Fail-Fast Secret Validation | ✅ Complete | [#17](https://github.com/anbuneel/ai-council/pull/17) |
 | 1.3 | Complete Database Migrations | ⏳ Pending | - |
 | 1.4 | Rate Limiting & Request Size Limits | ⏳ Pending | - |
 | 2.x | Medium Priority Fixes | ⏳ Pending | - |
@@ -44,50 +44,21 @@
 
 ---
 
-### 1.2 Fail-Fast Secret Validation
+### 1.2 Fail-Fast Secret Validation ✅ COMPLETED
 
-**Files to modify:**
-- `backend/config.py`
-- `backend/main.py` (app startup)
+**Status:** Implemented in PR #17 (`security/fail-fast-secrets`)
+**Completed:** 2025-12-28
 
-**Implementation steps:**
+**Files modified:**
+- `backend/config.py` - Added `IS_PRODUCTION` detection and `validate_secrets()` function
+- `backend/main.py` - Calls `validate_secrets()` in lifespan startup
 
-1. **Add production detection**
-   ```python
-   # backend/config.py
-   import os
-
-   IS_PRODUCTION = os.getenv("FLY_APP_NAME") is not None or os.getenv("VERCEL") is not None
-   ```
-
-2. **Add startup validation function**
-   ```python
-   # backend/config.py
-   def validate_secrets():
-       errors = []
-
-       if IS_PRODUCTION:
-           if JWT_SECRET == "change-me-in-production":
-               errors.append("JWT_SECRET must be set in production")
-           if not API_KEY_ENCRYPTION_KEY:
-               errors.append("API_KEY_ENCRYPTION_KEY must be set in production")
-           if not GOOGLE_CLIENT_ID or not GOOGLE_CLIENT_SECRET:
-               errors.append("Google OAuth credentials must be set in production")
-           if not GITHUB_CLIENT_ID or not GITHUB_CLIENT_SECRET:
-               errors.append("GitHub OAuth credentials must be set in production")
-
-       if errors:
-           raise RuntimeError("Configuration errors:\n" + "\n".join(errors))
-   ```
-
-3. **Call validation in app lifespan**
-   ```python
-   # backend/main.py
-   @asynccontextmanager
-   async def lifespan(app: FastAPI):
-       validate_secrets()  # Fail fast
-       # ... existing startup code
-   ```
+**Implementation details:**
+- Production detection via `FLY_APP_NAME` or `PRODUCTION=true` env vars
+- Validates at startup: JWT_SECRET, API_KEY_ENCRYPTION_KEY, OAuth credentials, DATABASE_URL
+- In production: raises `RuntimeError` with all errors listed (fails fast)
+- In development: logs warnings only, allows app to start
+- Provides helpful error messages with generation commands for keys
 
 ---
 


### PR DESCRIPTION
## Summary

Implements fail-fast secret validation that runs at application startup. In production, the app will refuse to start if required secrets are missing or using default values.

**Addresses:** High priority finding from security review - "JWT secret has default value" and "API key encryption key not checked at startup"

## Changes

### `backend/config.py`
- Added `IS_PRODUCTION` detection (checks for `FLY_APP_NAME` or `PRODUCTION=true`)
- Added `validate_secrets()` function with comprehensive validation

### `backend/main.py`
- Calls `validate_secrets()` in lifespan startup (before database pool init)

## Secrets Validated

| Secret | Validation |
|--------|------------|
| `JWT_SECRET` | Must not be default "change-me-in-production" |
| `API_KEY_ENCRYPTION_KEY` | Must be set (required for API key storage) |
| `GOOGLE_CLIENT_ID/SECRET` | Must be set (required for Google OAuth) |
| `GITHUB_CLIENT_ID/SECRET` | Must be set (required for GitHub OAuth) |
| `DATABASE_URL` | Must be set (required for PostgreSQL) |

## Behavior

| Environment | Missing Secrets | Result |
|-------------|-----------------|--------|
| Production (`IS_PRODUCTION=true`) | Any missing | `RuntimeError` raised, app fails to start |
| Development (`IS_PRODUCTION=false`) | Any missing | Warnings logged, app starts normally |

## Test Plan

- [x] Dev mode: App starts with warnings when secrets missing
- [x] Production mode: App fails with clear error message listing all missing secrets
- [x] Backend imports successfully
- [ ] Manual: Deploy to Fly.io staging with missing secret, verify startup failure

## Example Error Output (Production)

```
RuntimeError: Configuration errors detected:
  - JWT_SECRET must be set to a secure value in production
  - API_KEY_ENCRYPTION_KEY must be set in production. Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
  - DATABASE_URL must be set in production
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)