### PR TITLE
Add Account page with Financial Gazette editorial styling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,11 +140,13 @@ Note: If `DATABASE_URL` is not set, backend falls back to local JSON storage in 
 - `components/Sidebar.jsx` - Inquiry list, mobile drawer
 - `components/OAuthCallback.jsx` - Handles OAuth provider redirects
 - `components/Login.jsx` - OAuth login UI (Google and GitHub buttons)
-- `components/Settings.jsx` - Balance display, deposit options, usage history
-- `components/CreditBalance.jsx` - Header dollar balance indicator
+- `components/Account.jsx` - Account page: balance, deposits, usage history, member info
+- `components/BalanceCard.jsx` - Balance card with stats (used in Account page)
+- `components/TransactionLedger.jsx` - Transaction history with expandable details
+- `components/CreditBalance.jsx` - Header dollar balance indicator (links to Account page)
 - `components/PaymentSuccess.jsx` - Post-checkout success page
 - `components/PaymentCancel.jsx` - Checkout cancelled page
-- `components/AvatarMenu.jsx` - User avatar dropdown with settings/logout
+- `components/AvatarMenu.jsx` - User avatar dropdown with account/logout
 - `components/ConfirmDialog.jsx` - Custom styled confirmation/alert dialogs
 - `api.js` - Backend communication with OAuth auth, JWT tokens, billing API, SSE streaming
 
@@ -639,7 +641,7 @@ A comprehensive security review was conducted on 2025-12-28 (see `docs/ai-counci
 
 **Completed accessibility/polish fixes (Phase 3 - Low):**
 - [x] Archive items keyboard accessibility - `frontend/src/components/Sidebar.jsx`
-- [x] Settings modal dialog semantics with focus trap - `frontend/src/components/Settings.jsx`
+- [x] Settings modal replaced with Account page - `frontend/src/components/Account.jsx`
 - [x] Local storage API key ID fix - `backend/storage_local.py`
 - [x] Documentation field name corrections - `CLAUDE.md`, `AGENTS.md`
 

--- a/docs/DESIGN_account_page.md
+++ b/docs/DESIGN_account_page.md
@@ -1,5 +1,8 @@
 # Account Page Design Recommendation
 
+> **STATUS: IMPLEMENTED** (2026-01-02)
+> The Account page is now live at `/account`, replacing the Settings modal.
+
 ## Decision: Separate Page vs Modal
 
 **Verdict: Settings should be a dedicated Account page, not a modal.**

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -56,7 +56,13 @@ Chronological reference to all project documentation.
 | [IMPLEMENTATION_PLAN_stripe_credits.md](IMPLEMENTATION_PLAN_stripe_credits.md) | Credit-based monetization with Stripe (superseded by usage-based billing) |
 | [byok_friction_recommendations_codex.md](byok_friction_recommendations_codex.md) | BYOK friction reduction recommendations |
 | [IMPLEMENTATION_PLAN_usage_based_billing.md](IMPLEMENTATION_PLAN_usage_based_billing.md) | Usage-based billing plan (implemented) |
-| [DESIGN_account_page.md](DESIGN_account_page.md) | **[PENDING]** Account page design - replaces Settings modal |
+| [DESIGN_account_page.md](DESIGN_account_page.md) | **[IMPLEMENTED]** Account page design - replaces Settings modal |
+
+## 2026-01-02
+
+| Document | Description |
+|----------|-------------|
+| Account Page implementation | Dedicated `/account` page with "Financial Gazette" editorial styling |
 
 ### Claude Sessions
 | Document | Description |
@@ -73,9 +79,15 @@ Chronological reference to all project documentation.
 
 ## Current Focus
 
+**Account Page** - Implemented! A dedicated Account page at `/account` with "Financial Gazette" editorial styling:
+- Balance card with stats
+- Deposit options ($5/$20/$50)
+- Transaction ledger with expandable cost breakdowns
+- Member info section
+
 **Usage-Based Billing** - Implemented! Users now pay actual OpenRouter cost + 10% margin per query. The system tracks costs transparently with breakdown shown after each query.
 
-**Next Steps:**
-1. Run database migration on production: `006_usage_based_billing.sql`
-2. Test complete flow: deposit → query → cost deduction → usage history
-3. Consider Account Page redesign (replace Settings modal with dedicated page)
+**Completed:**
+1. [x] Database migration on production: `006_usage_based_billing.sql`
+2. [x] Account page replaces Settings modal
+3. [ ] Test complete flow: deposit → query → cost deduction → usage history

--- a/frontend/src/components/Account.css
+++ b/frontend/src/components/Account.css
@@ -1,0 +1,628 @@
+/* ==========================================================================
+   Account Page - "The Financial Gazette" Editorial Theme
+   A newspaper financial section aesthetic with Victorian banking ledger touches
+   ========================================================================== */
+
+.account-page {
+  position: relative;
+  min-height: 100vh;
+  background: var(--paper-cream, #FAF8F5);
+  padding: 2rem;
+  overflow-x: hidden;
+
+  /* Subtle paper texture */
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
+  background-blend-mode: overlay;
+}
+
+/* Decorative corner flourishes */
+.account-flourish {
+  position: fixed;
+  width: 80px;
+  height: 80px;
+  pointer-events: none;
+  opacity: 0.15;
+  z-index: 0;
+}
+
+.account-flourish::before,
+.account-flourish::after {
+  content: '';
+  position: absolute;
+  background: var(--ink-black, #1A1614);
+}
+
+.account-flourish-tl {
+  top: 1rem;
+  left: 1rem;
+}
+.account-flourish-tl::before {
+  width: 40px;
+  height: 2px;
+  top: 0;
+  left: 0;
+}
+.account-flourish-tl::after {
+  width: 2px;
+  height: 40px;
+  top: 0;
+  left: 0;
+}
+
+.account-flourish-tr {
+  top: 1rem;
+  right: 1rem;
+}
+.account-flourish-tr::before {
+  width: 40px;
+  height: 2px;
+  top: 0;
+  right: 0;
+}
+.account-flourish-tr::after {
+  width: 2px;
+  height: 40px;
+  top: 0;
+  right: 0;
+}
+
+.account-flourish-bl {
+  bottom: 1rem;
+  left: 1rem;
+}
+.account-flourish-bl::before {
+  width: 40px;
+  height: 2px;
+  bottom: 0;
+  left: 0;
+}
+.account-flourish-bl::after {
+  width: 2px;
+  height: 40px;
+  bottom: 0;
+  left: 0;
+}
+
+.account-flourish-br {
+  bottom: 1rem;
+  right: 1rem;
+}
+.account-flourish-br::before {
+  width: 40px;
+  height: 2px;
+  bottom: 0;
+  right: 0;
+}
+.account-flourish-br::after {
+  width: 2px;
+  height: 40px;
+  bottom: 0;
+  right: 0;
+}
+
+/* ==========================================================================
+   Masthead / Header
+   ========================================================================== */
+
+.account-masthead {
+  position: relative;
+  max-width: 1200px;
+  margin: 0 auto 1.5rem;
+  text-align: center;
+  animation: fadeInDown 0.6s ease-out;
+}
+
+@keyframes fadeInDown {
+  from {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.account-back {
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: none;
+  border: 1px solid transparent;
+  color: var(--ink-dark, #2D2926);
+  font-family: var(--font-ui, 'IBM Plex Sans', sans-serif);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.account-back svg {
+  width: 18px;
+  height: 18px;
+}
+
+.account-back:hover {
+  border-color: var(--ink-black, #1A1614);
+  color: var(--ink-black, #1A1614);
+}
+
+.account-masthead-center {
+  display: inline-block;
+}
+
+.account-masthead-rule {
+  height: 3px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--ink-black, #1A1614) 20%,
+    var(--ink-black, #1A1614) 80%,
+    transparent
+  );
+  margin: 0.5rem 0;
+}
+
+.account-title {
+  margin: 0;
+  font-family: var(--font-display, 'Playfair Display', Georgia, serif);
+  font-size: clamp(2.5rem, 5vw, 4rem);
+  font-weight: 900;
+  color: var(--ink-black, #1A1614);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.account-subtitle {
+  margin: 0.25rem 0 0;
+  font-family: var(--font-body, 'Source Serif 4', Georgia, serif);
+  font-size: 1rem;
+  font-style: italic;
+  color: var(--ink-dark, #2D2926);
+  letter-spacing: 0.05em;
+}
+
+.account-masthead-date {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+  font-size: 0.75rem;
+  color: var(--ink-gray, #666);
+  text-align: right;
+}
+
+/* ==========================================================================
+   Section Divider
+   ========================================================================== */
+
+.account-divider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 1200px;
+  margin: 0 auto 2rem;
+}
+
+.account-divider::before,
+.account-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--ink-black, #1A1614);
+}
+
+.account-divider-ornament {
+  padding: 0 1.5rem;
+  font-size: 1.25rem;
+  color: var(--ink-black, #1A1614);
+}
+
+/* ==========================================================================
+   Error Message
+   ========================================================================== */
+
+.account-error {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  max-width: 1200px;
+  margin: 0 auto 1.5rem;
+  padding: 1rem 1.25rem;
+  background: rgba(196, 61, 46, 0.08);
+  border-left: 4px solid var(--accent-vermillion, #C43D2E);
+  color: var(--accent-vermillion, #C43D2E);
+  font-family: var(--font-ui, 'IBM Plex Sans', sans-serif);
+  font-size: 0.9375rem;
+  animation: slideIn 0.3s ease-out;
+}
+
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateX(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.account-error-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  background: var(--accent-vermillion, #C43D2E);
+  color: white;
+  font-weight: 700;
+  font-size: 0.875rem;
+  border-radius: 50%;
+}
+
+/* ==========================================================================
+   Main Content - Two Column Layout
+   ========================================================================== */
+
+.account-content {
+  display: grid;
+  grid-template-columns: 1fr 1.2fr;
+  gap: 3rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  animation: fadeIn 0.6s ease-out 0.2s both;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.account-column {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.account-section-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.account-section-header h2 {
+  margin: 0;
+  font-family: var(--font-display, 'Playfair Display', Georgia, serif);
+  font-size: 1.25rem;
+  font-weight: 700;
+  font-style: italic;
+  color: var(--ink-dark, #2D2926);
+  white-space: nowrap;
+}
+
+.account-section-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--ink-black, #1A1614);
+  opacity: 0.3;
+}
+
+/* ==========================================================================
+   Deposit Options
+   ========================================================================== */
+
+.deposit-options {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.deposit-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background: var(--paper-aged, #F5F0E8);
+  border: 2px solid var(--ink-black, #1A1614);
+  padding: 0;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  animation: slideUp 0.5s ease-out both;
+  overflow: hidden;
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.deposit-card:hover:not(:disabled) {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 24px rgba(26, 22, 20, 0.15);
+}
+
+.deposit-card:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.deposit-card-featured {
+  border-width: 3px;
+  background: var(--paper-cream, #FAF8F5);
+}
+
+.deposit-card-featured::before {
+  content: 'Popular';
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 0.25rem 0.75rem;
+  background: var(--accent-forest, #2D5A3D);
+  color: white;
+  font-family: var(--font-ui, 'IBM Plex Sans', sans-serif);
+  font-size: 0.625rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.deposit-card-inner {
+  padding: 1.5rem 1rem;
+  text-align: center;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.deposit-amount {
+  font-family: var(--font-display, 'Playfair Display', Georgia, serif);
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: var(--ink-black, #1A1614);
+  line-height: 1;
+}
+
+.deposit-label {
+  font-family: var(--font-ui, 'IBM Plex Sans', sans-serif);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ink-dark, #2D2926);
+}
+
+.deposit-estimate {
+  font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+  font-size: 0.75rem;
+  color: var(--ink-gray, #666);
+  margin-top: 0.5rem;
+}
+
+.deposit-card-action {
+  padding: 0.75rem;
+  background: var(--ink-black, #1A1614);
+  color: var(--paper-cream, #FAF8F5);
+  font-family: var(--font-ui, 'IBM Plex Sans', sans-serif);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  text-align: center;
+  transition: background 0.2s;
+}
+
+.deposit-card:hover:not(:disabled) .deposit-card-action {
+  background: var(--accent-forest, #2D5A3D);
+}
+
+.deposit-loading {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.loading-line {
+  height: 100px;
+  background: linear-gradient(
+    90deg,
+    var(--paper-aged, #F5F0E8) 0%,
+    var(--paper-cream, #FAF8F5) 50%,
+    var(--paper-aged, #F5F0E8) 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+  border: 1px solid var(--border-light, #E5E0D8);
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.deposit-note {
+  font-family: var(--font-body, 'Source Serif 4', Georgia, serif);
+  font-size: 0.875rem;
+  color: var(--ink-gray, #666);
+  line-height: 1.6;
+  font-style: italic;
+  margin: 0;
+}
+
+/* ==========================================================================
+   Member Card
+   ========================================================================== */
+
+.member-card {
+  background: var(--paper-aged, #F5F0E8);
+  border: 2px solid var(--ink-black, #1A1614);
+  animation: slideUp 0.5s ease-out 0.3s both;
+}
+
+.member-card-header {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--ink-black, #1A1614);
+  background: var(--ink-black, #1A1614);
+}
+
+.member-badge {
+  font-family: var(--font-ui, 'IBM Plex Sans', sans-serif);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--paper-cream, #FAF8F5);
+}
+
+.member-details {
+  padding: 1rem;
+}
+
+.member-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.625rem 0;
+  border-bottom: 1px dashed var(--border-light, #E5E0D8);
+}
+
+.member-row:last-child {
+  border-bottom: none;
+}
+
+.member-label {
+  font-family: var(--font-ui, 'IBM Plex Sans', sans-serif);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--ink-gray, #666);
+}
+
+.member-value {
+  font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+  font-size: 0.8125rem;
+  color: var(--ink-dark, #2D2926);
+  text-align: right;
+}
+
+.member-provider {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-transform: capitalize;
+}
+
+.provider-icon {
+  width: 16px;
+  height: 16px;
+}
+
+/* ==========================================================================
+   Footer
+   ========================================================================== */
+
+.account-footer {
+  max-width: 1200px;
+  margin: 4rem auto 0;
+  text-align: center;
+  animation: fadeIn 0.6s ease-out 0.4s both;
+}
+
+.account-footer-rule {
+  height: 2px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--ink-black, #1A1614) 20%,
+    var(--ink-black, #1A1614) 80%,
+    transparent
+  );
+  margin-bottom: 1rem;
+}
+
+.account-footer-text {
+  font-family: var(--font-ui, 'IBM Plex Sans', sans-serif);
+  font-size: 0.75rem;
+  color: var(--ink-gray, #666);
+  letter-spacing: 0.05em;
+}
+
+/* ==========================================================================
+   Responsive Design
+   ========================================================================== */
+
+@media (max-width: 1024px) {
+  .account-content {
+    grid-template-columns: 1fr;
+    gap: 2rem;
+  }
+
+  .account-column-right {
+    order: -1;
+  }
+}
+
+@media (max-width: 768px) {
+  .account-page {
+    padding: 1rem;
+  }
+
+  .account-flourish {
+    display: none;
+  }
+
+  .account-back {
+    position: static;
+    transform: none;
+    margin-bottom: 1rem;
+  }
+
+  .account-back span {
+    display: none;
+  }
+
+  .account-masthead-date {
+    position: static;
+    transform: none;
+    margin-top: 0.5rem;
+  }
+
+  .account-masthead {
+    text-align: center;
+  }
+
+  .deposit-options {
+    grid-template-columns: 1fr;
+  }
+
+  .deposit-card-inner {
+    padding: 1.25rem 1rem;
+  }
+
+  .deposit-amount {
+    font-size: 2rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .account-title {
+    letter-spacing: 0.08em;
+  }
+
+  .account-section-header h2 {
+    font-size: 1.125rem;
+  }
+}

--- a/frontend/src/components/Account.jsx
+++ b/frontend/src/components/Account.jsx
@@ -1,0 +1,276 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { billing, auth } from '../api';
+import BalanceCard from './BalanceCard';
+import TransactionLedger from './TransactionLedger';
+import './Account.css';
+
+function Account({ onRefreshBalance }) {
+  const navigate = useNavigate();
+  const [userInfo, setUserInfo] = useState(null);
+  const [balance, setBalance] = useState(null);
+  const [depositOptions, setDepositOptions] = useState([]);
+  const [usageHistory, setUsageHistory] = useState([]);
+  const [isLoadingBalance, setIsLoadingBalance] = useState(true);
+  const [isLoadingOptions, setIsLoadingOptions] = useState(true);
+  const [isLoadingHistory, setIsLoadingHistory] = useState(true);
+  const [isPurchasing, setIsPurchasing] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    loadAllData();
+  }, []);
+
+  const loadAllData = async () => {
+    await Promise.all([
+      loadUserInfo(),
+      loadBalance(),
+      loadDepositOptions(),
+      loadUsageHistory(),
+    ]);
+  };
+
+  const loadUserInfo = async () => {
+    try {
+      const user = await auth.getMe();
+      setUserInfo(user);
+    } catch (err) {
+      console.error('Failed to load user info:', err);
+    }
+  };
+
+  const loadBalance = async () => {
+    setIsLoadingBalance(true);
+    try {
+      const data = await billing.getBalance();
+      setBalance(data);
+      if (onRefreshBalance) onRefreshBalance();
+    } catch (err) {
+      setError('Failed to load balance');
+    } finally {
+      setIsLoadingBalance(false);
+    }
+  };
+
+  const loadDepositOptions = async () => {
+    setIsLoadingOptions(true);
+    try {
+      const data = await billing.getDepositOptions();
+      setDepositOptions(data);
+    } catch (err) {
+      console.error('Failed to load deposit options:', err);
+    } finally {
+      setIsLoadingOptions(false);
+    }
+  };
+
+  const loadUsageHistory = async () => {
+    setIsLoadingHistory(true);
+    try {
+      const data = await billing.getUsageHistory();
+      setUsageHistory(data);
+    } catch (err) {
+      console.error('Failed to load usage history:', err);
+    } finally {
+      setIsLoadingHistory(false);
+    }
+  };
+
+  const handleDeposit = async (optionId) => {
+    setIsPurchasing(true);
+    setError('');
+    try {
+      await billing.purchaseDeposit(optionId);
+      // Redirect happens in purchaseDeposit
+    } catch (err) {
+      setError(err.message || 'Failed to process deposit');
+      setIsPurchasing(false);
+    }
+  };
+
+  const handleBack = () => {
+    navigate('/');
+  };
+
+  const formatDate = (dateString) => {
+    if (!dateString) return '';
+    return new Date(dateString).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  };
+
+  return (
+    <div className="account-page">
+      {/* Decorative corner flourishes */}
+      <div className="account-flourish account-flourish-tl" aria-hidden="true" />
+      <div className="account-flourish account-flourish-tr" aria-hidden="true" />
+      <div className="account-flourish account-flourish-bl" aria-hidden="true" />
+      <div className="account-flourish account-flourish-br" aria-hidden="true" />
+
+      {/* Header / Masthead */}
+      <header className="account-masthead">
+        <button className="account-back" onClick={handleBack} aria-label="Return to Council">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M19 12H5M12 19l-7-7 7-7" />
+          </svg>
+          <span>Return to Council</span>
+        </button>
+
+        <div className="account-masthead-center">
+          <div className="account-masthead-rule" />
+          <h1 className="account-title">Account</h1>
+          <p className="account-subtitle">Financial Record & Membership</p>
+          <div className="account-masthead-rule" />
+        </div>
+
+        <div className="account-masthead-date">
+          {new Date().toLocaleDateString('en-US', {
+            weekday: 'long',
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+          })}
+        </div>
+      </header>
+
+      {/* Section divider */}
+      <div className="account-divider">
+        <span className="account-divider-ornament">&#10041;</span>
+      </div>
+
+      {error && (
+        <div className="account-error">
+          <span className="account-error-icon">!</span>
+          {error}
+        </div>
+      )}
+
+      {/* Main content - two column layout */}
+      <main className="account-content">
+        {/* Left column: Balance + Funds */}
+        <section className="account-column account-column-left">
+          <BalanceCard
+            balance={balance}
+            isLoading={isLoadingBalance}
+          />
+
+          <div className="account-section-header">
+            <span className="account-section-rule" />
+            <h2>Add Funds</h2>
+            <span className="account-section-rule" />
+          </div>
+
+          <div className="deposit-options">
+            {isLoadingOptions ? (
+              <div className="deposit-loading">
+                <div className="loading-line" />
+                <div className="loading-line" />
+                <div className="loading-line" />
+              </div>
+            ) : (
+              depositOptions.map((option, index) => (
+                <button
+                  key={option.id}
+                  className={`deposit-card ${index === 1 ? 'deposit-card-featured' : ''}`}
+                  onClick={() => handleDeposit(option.id)}
+                  disabled={isPurchasing}
+                  style={{ animationDelay: `${index * 0.1}s` }}
+                >
+                  <div className="deposit-card-inner">
+                    <span className="deposit-amount">
+                      ${(option.amount_cents / 100).toFixed(0)}
+                    </span>
+                    <span className="deposit-label">{option.name}</span>
+                    <span className="deposit-estimate">
+                      ~{Math.round(option.amount_cents / 5)} inquiries
+                    </span>
+                  </div>
+                  <div className="deposit-card-action">
+                    {isPurchasing ? 'Processing...' : 'Deposit'}
+                  </div>
+                </button>
+              ))
+            )}
+          </div>
+
+          <p className="deposit-note">
+            Each inquiry costs approximately $0.02–$0.10 depending on the AI models used.
+            You pay only for what you use, plus a 10% service fee.
+          </p>
+
+          {/* Member info card */}
+          {userInfo && (
+            <>
+              <div className="account-section-header">
+                <span className="account-section-rule" />
+                <h2>Membership</h2>
+                <span className="account-section-rule" />
+              </div>
+
+              <div className="member-card">
+                <div className="member-card-header">
+                  <span className="member-badge">Member</span>
+                </div>
+                <div className="member-details">
+                  <div className="member-row">
+                    <span className="member-label">Email</span>
+                    <span className="member-value">{userInfo.email}</span>
+                  </div>
+                  <div className="member-row">
+                    <span className="member-label">Provider</span>
+                    <span className="member-value member-provider">
+                      {userInfo.oauth_provider === 'google' && (
+                        <svg viewBox="0 0 24 24" className="provider-icon">
+                          <path fill="currentColor" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+                          <path fill="currentColor" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                          <path fill="currentColor" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+                          <path fill="currentColor" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+                        </svg>
+                      )}
+                      {userInfo.oauth_provider === 'github' && (
+                        <svg viewBox="0 0 24 24" className="provider-icon">
+                          <path fill="currentColor" d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/>
+                        </svg>
+                      )}
+                      {userInfo.oauth_provider}
+                    </span>
+                  </div>
+                  <div className="member-row">
+                    <span className="member-label">Member since</span>
+                    <span className="member-value">{formatDate(userInfo.created_at)}</span>
+                  </div>
+                </div>
+              </div>
+            </>
+          )}
+        </section>
+
+        {/* Right column: Transaction Ledger */}
+        <section className="account-column account-column-right">
+          <div className="account-section-header">
+            <span className="account-section-rule" />
+            <h2>Transaction Ledger</h2>
+            <span className="account-section-rule" />
+          </div>
+
+          <TransactionLedger
+            transactions={usageHistory}
+            isLoading={isLoadingHistory}
+          />
+        </section>
+      </main>
+
+      {/* Footer */}
+      <footer className="account-footer">
+        <div className="account-footer-rule" />
+        <p className="account-footer-text">
+          The AI Council &middot; Est. 2024 &middot; Transparent Usage-Based Billing
+        </p>
+      </footer>
+    </div>
+  );
+}
+
+export default Account;

--- a/frontend/src/components/AvatarMenu.jsx
+++ b/frontend/src/components/AvatarMenu.jsx
@@ -1,16 +1,17 @@
 import { useState, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
 import './AvatarMenu.css';
 
 /**
  * Avatar dropdown menu for user account actions.
- * Shows user initial or profile picture, with dropdown for settings/logout.
+ * Shows user initial or profile picture, with dropdown for account/logout.
  */
 export default function AvatarMenu({
   userEmail,
   avatarUrl,
-  onOpenSettings,
   onLogout,
 }) {
+  const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef(null);
 
@@ -35,9 +36,9 @@ export default function AvatarMenu({
     setIsOpen(!isOpen);
   };
 
-  const handleSettings = () => {
+  const handleAccount = () => {
     setIsOpen(false);
-    onOpenSettings?.();
+    navigate('/account');
   };
 
   const handleLogout = () => {
@@ -78,14 +79,14 @@ export default function AvatarMenu({
               <button
                 type="button"
                 className="avatar-dropdown-item"
-                onClick={handleSettings}
+                onClick={handleAccount}
                 role="menuitem"
               >
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <circle cx="12" cy="12" r="3"></circle>
-                  <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+                  <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
+                  <circle cx="12" cy="7" r="4"></circle>
                 </svg>
-                Settings
+                Account
               </button>
               <div className="avatar-dropdown-divider" role="separator" />
               <button

--- a/frontend/src/components/BalanceCard.css
+++ b/frontend/src/components/BalanceCard.css
@@ -1,0 +1,296 @@
+/* ==========================================================================
+   Balance Card - Stock Certificate / Market Indicator Style
+   ========================================================================== */
+
+.balance-card {
+  position: relative;
+  padding: 3px;
+  background: var(--ink-black, #1A1614);
+  animation: slideUp 0.5s ease-out both;
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Ornate corner decorations */
+.balance-card-corner {
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  z-index: 1;
+}
+
+.balance-card-corner::before,
+.balance-card-corner::after {
+  content: '';
+  position: absolute;
+  background: var(--accent-forest, #2D5A3D);
+}
+
+.balance-card-corner-tl {
+  top: 8px;
+  left: 8px;
+}
+.balance-card-corner-tl::before {
+  width: 100%;
+  height: 3px;
+  top: 0;
+  left: 0;
+}
+.balance-card-corner-tl::after {
+  width: 3px;
+  height: 100%;
+  top: 0;
+  left: 0;
+}
+
+.balance-card-corner-tr {
+  top: 8px;
+  right: 8px;
+}
+.balance-card-corner-tr::before {
+  width: 100%;
+  height: 3px;
+  top: 0;
+  right: 0;
+}
+.balance-card-corner-tr::after {
+  width: 3px;
+  height: 100%;
+  top: 0;
+  right: 0;
+}
+
+.balance-card-corner-bl {
+  bottom: 8px;
+  left: 8px;
+}
+.balance-card-corner-bl::before {
+  width: 100%;
+  height: 3px;
+  bottom: 0;
+  left: 0;
+}
+.balance-card-corner-bl::after {
+  width: 3px;
+  height: 100%;
+  bottom: 0;
+  left: 0;
+}
+
+.balance-card-corner-br {
+  bottom: 8px;
+  right: 8px;
+}
+.balance-card-corner-br::before {
+  width: 100%;
+  height: 3px;
+  bottom: 0;
+  right: 0;
+}
+.balance-card-corner-br::after {
+  width: 3px;
+  height: 100%;
+  bottom: 0;
+  right: 0;
+}
+
+.balance-card-frame {
+  background: var(--paper-cream, #FAF8F5);
+  padding: 2rem;
+  text-align: center;
+
+  /* Inner border effect */
+  box-shadow: inset 0 0 0 1px var(--ink-black, #1A1614);
+}
+
+/* Header */
+.balance-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.balance-header-ornament {
+  color: var(--accent-forest, #2D5A3D);
+  font-size: 0.625rem;
+}
+
+.balance-header-text {
+  font-family: var(--font-ui, 'IBM Plex Sans', sans-serif);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--ink-dark, #2D2926);
+}
+
+/* Balance Amount */
+.balance-amount-wrapper {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  margin-bottom: 0.75rem;
+}
+
+.balance-currency {
+  font-family: var(--font-display, 'Playfair Display', Georgia, serif);
+  font-size: 1.75rem;
+  font-weight: 400;
+  color: var(--ink-dark, #2D2926);
+  margin-top: 0.5rem;
+  margin-right: 0.25rem;
+}
+
+.balance-amount {
+  font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+  font-size: 4rem;
+  font-weight: 700;
+  color: var(--ink-black, #1A1614);
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+
+/* Available indicator */
+.balance-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.balance-indicator-dot {
+  width: 8px;
+  height: 8px;
+  background: var(--accent-forest, #2D5A3D);
+  border-radius: 50%;
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.6;
+    transform: scale(0.9);
+  }
+}
+
+.balance-indicator-text {
+  font-family: var(--font-ui, 'IBM Plex Sans', sans-serif);
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--accent-forest, #2D5A3D);
+}
+
+/* Stats row */
+.balance-stats {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border-light, #E5E0D8);
+}
+
+.balance-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.balance-stat-label {
+  font-family: var(--font-ui, 'IBM Plex Sans', sans-serif);
+  font-size: 0.625rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ink-gray, #666);
+}
+
+.balance-stat-value {
+  font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.balance-stat-value.positive {
+  color: var(--accent-forest, #2D5A3D);
+}
+
+.balance-stat-value.negative {
+  color: var(--accent-vermillion, #C43D2E);
+}
+
+.balance-stat-divider {
+  width: 1px;
+  height: 30px;
+  background: var(--border-light, #E5E0D8);
+}
+
+/* Loading state */
+.balance-card-loading .balance-card-frame {
+  min-height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.balance-loading-shimmer {
+  width: 60%;
+  height: 60px;
+  background: linear-gradient(
+    90deg,
+    var(--paper-aged, #F5F0E8) 0%,
+    var(--paper-cream, #FAF8F5) 50%,
+    var(--paper-aged, #F5F0E8) 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* Responsive */
+@media (max-width: 480px) {
+  .balance-card-frame {
+    padding: 1.5rem 1rem;
+  }
+
+  .balance-amount {
+    font-size: 3rem;
+  }
+
+  .balance-currency {
+    font-size: 1.25rem;
+  }
+
+  .balance-stats {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .balance-stat-divider {
+    width: 60px;
+    height: 1px;
+  }
+}

--- a/frontend/src/components/BalanceCard.jsx
+++ b/frontend/src/components/BalanceCard.jsx
@@ -1,0 +1,69 @@
+import './BalanceCard.css';
+
+function BalanceCard({ balance, isLoading }) {
+  const formatBalance = (amount) => {
+    if (amount === null || amount === undefined) return '0.00';
+    return parseFloat(amount).toFixed(2);
+  };
+
+  const formatStat = (amount) => {
+    if (amount === null || amount === undefined) return '$0.00';
+    return `$${parseFloat(amount).toFixed(2)}`;
+  };
+
+  if (isLoading) {
+    return (
+      <div className="balance-card balance-card-loading">
+        <div className="balance-card-frame">
+          <div className="balance-loading-shimmer" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="balance-card">
+      {/* Ornate frame corners */}
+      <div className="balance-card-corner balance-card-corner-tl" aria-hidden="true" />
+      <div className="balance-card-corner balance-card-corner-tr" aria-hidden="true" />
+      <div className="balance-card-corner balance-card-corner-bl" aria-hidden="true" />
+      <div className="balance-card-corner balance-card-corner-br" aria-hidden="true" />
+
+      <div className="balance-card-frame">
+        <div className="balance-header">
+          <span className="balance-header-ornament">&#9830;</span>
+          <span className="balance-header-text">Current Balance</span>
+          <span className="balance-header-ornament">&#9830;</span>
+        </div>
+
+        <div className="balance-amount-wrapper">
+          <span className="balance-currency">$</span>
+          <span className="balance-amount">{formatBalance(balance?.balance)}</span>
+        </div>
+
+        <div className="balance-indicator">
+          <span className="balance-indicator-dot" />
+          <span className="balance-indicator-text">Available</span>
+        </div>
+
+        <div className="balance-stats">
+          <div className="balance-stat">
+            <span className="balance-stat-label">Total Deposited</span>
+            <span className="balance-stat-value positive">
+              {formatStat(balance?.total_deposited)}
+            </span>
+          </div>
+          <div className="balance-stat-divider" />
+          <div className="balance-stat">
+            <span className="balance-stat-label">Total Spent</span>
+            <span className="balance-stat-value negative">
+              {formatStat(balance?.total_spent)}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default BalanceCard;

--- a/frontend/src/components/ChatInterface.jsx
+++ b/frontend/src/components/ChatInterface.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useLayoutEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import rehypeSanitize from 'rehype-sanitize';
 import Stage1 from './Stage1';
@@ -74,10 +75,11 @@ export default function ChatInterface({
     // User controls
     userEmail,
     userBalance,
-    onOpenSettings,
     onLogout,
     onNewInquiry,
 }) {
+    const navigate = useNavigate();
+    const handleOpenAccount = () => navigate('/account');
     const [input, setInput] = useState('');
     const [activeTab, setActiveTab] = useState('final');
 
@@ -185,11 +187,10 @@ export default function ChatInterface({
                             <p className="masthead-tagline">Synthesized knowledge from AI experts</p>
                         </div>
                         <div className="masthead-actions">
-                            <CreditBalance balance={userBalance} onClick={onOpenSettings} />
+                            <CreditBalance balance={userBalance} onClick={handleOpenAccount} />
                             <AvatarMenu
                                 userEmail={userEmail}
-                                onOpenSettings={onOpenSettings}
-                                onLogout={onLogout}
+                                                                onLogout={onLogout}
                             />
                         </div>
                     </div>
@@ -242,11 +243,10 @@ export default function ChatInterface({
                                 <span className="masthead-btn-label">New Inquiry</span>
                             </button>
                         )}
-                        <CreditBalance balance={userBalance} onClick={onOpenSettings} />
+                        <CreditBalance balance={userBalance} onClick={handleOpenAccount} />
                         <AvatarMenu
                             userEmail={userEmail}
-                            onOpenSettings={onOpenSettings}
-                            onLogout={onLogout}
+                                                        onLogout={onLogout}
                         />
                     </div>
                 </div>

--- a/frontend/src/components/TransactionLedger.css
+++ b/frontend/src/components/TransactionLedger.css
@@ -1,0 +1,435 @@
+/* ==========================================================================
+   Transaction Ledger - Victorian Banking Ledger Style
+   ========================================================================== */
+
+.ledger {
+  background: var(--paper-aged, #F5F0E8);
+  border: 2px solid var(--ink-black, #1A1614);
+  animation: slideUp 0.5s ease-out both;
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Header row */
+.ledger-header-row {
+  display: grid;
+  grid-template-columns: 100px 1fr 120px;
+  gap: 1rem;
+  padding: 0.875rem 1.25rem;
+  background: var(--ink-black, #1A1614);
+  color: var(--paper-cream, #FAF8F5);
+  font-family: var(--font-ui, 'IBM Plex Sans', sans-serif);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.ledger-col-date {
+  text-align: left;
+}
+
+.ledger-col-desc {
+  text-align: left;
+}
+
+.ledger-col-amount {
+  text-align: right;
+}
+
+/* Ledger body */
+.ledger-body {
+  max-height: 500px;
+  overflow-y: auto;
+}
+
+/* Custom scrollbar */
+.ledger-body::-webkit-scrollbar {
+  width: 8px;
+}
+
+.ledger-body::-webkit-scrollbar-track {
+  background: var(--paper-aged, #F5F0E8);
+}
+
+.ledger-body::-webkit-scrollbar-thumb {
+  background: var(--ink-gray, #999);
+  border: 2px solid var(--paper-aged, #F5F0E8);
+}
+
+.ledger-body::-webkit-scrollbar-thumb:hover {
+  background: var(--ink-dark, #2D2926);
+}
+
+/* Ledger row */
+.ledger-row {
+  border-bottom: 1px solid var(--border-light, #E5E0D8);
+  animation: fadeIn 0.3s ease-out both;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.ledger-row:nth-child(even) {
+  background: rgba(245, 240, 232, 0.5);
+}
+
+.ledger-row:hover {
+  background: var(--paper-cream, #FAF8F5);
+}
+
+.ledger-row-main {
+  display: grid;
+  grid-template-columns: 100px 1fr 120px;
+  gap: 1rem;
+  width: 100%;
+  padding: 1rem 1.25rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.2s;
+}
+
+.ledger-row-main:focus {
+  outline: none;
+  background: var(--paper-cream, #FAF8F5);
+}
+
+/* Date column */
+.ledger-row-main .ledger-col-date {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.ledger-date-day {
+  font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--ink-dark, #2D2926);
+}
+
+.ledger-date-time {
+  font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+  font-size: 0.6875rem;
+  color: var(--ink-gray, #888);
+}
+
+/* Description column */
+.ledger-row-main .ledger-col-desc {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.ledger-type-badge {
+  padding: 0.25rem 0.5rem;
+  background: var(--ink-black, #1A1614);
+  color: var(--paper-cream, #FAF8F5);
+  font-family: var(--font-ui, 'IBM Plex Sans', sans-serif);
+  font-size: 0.5625rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  white-space: nowrap;
+}
+
+.ledger-desc-text {
+  font-family: var(--font-body, 'Source Serif 4', Georgia, serif);
+  font-size: 0.9375rem;
+  color: var(--ink-dark, #2D2926);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Amount column */
+.ledger-row-main .ledger-col-amount {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.ledger-amount {
+  font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+  font-size: 0.9375rem;
+  font-weight: 600;
+}
+
+.ledger-amount.positive {
+  color: var(--accent-forest, #2D5A3D);
+}
+
+.ledger-amount.negative {
+  color: var(--accent-vermillion, #C43D2E);
+}
+
+.ledger-expand-icon {
+  width: 16px;
+  height: 16px;
+  color: var(--ink-gray, #888);
+  transition: transform 0.2s;
+}
+
+.ledger-expand-icon.expanded {
+  transform: rotate(180deg);
+}
+
+/* Expanded details */
+.ledger-row-details {
+  padding: 0 1.25rem 1.25rem;
+  border-top: 1px dashed var(--border-light, #E5E0D8);
+  margin-top: -0.25rem;
+  animation: expandIn 0.2s ease-out;
+}
+
+@keyframes expandIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.ledger-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  padding: 1rem;
+  background: var(--paper-cream, #FAF8F5);
+  border: 1px solid var(--border-light, #E5E0D8);
+  margin-top: 1rem;
+}
+
+.ledger-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  text-align: center;
+}
+
+.ledger-detail-label {
+  font-family: var(--font-ui, 'IBM Plex Sans', sans-serif);
+  font-size: 0.625rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-gray, #666);
+}
+
+.ledger-detail-value {
+  font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--ink-dark, #2D2926);
+}
+
+.ledger-detail-total {
+  background: var(--paper-aged, #F5F0E8);
+  margin: -1rem;
+  padding: 1rem;
+  border-left: 1px solid var(--border-light, #E5E0D8);
+}
+
+.ledger-detail-total .ledger-detail-value {
+  color: var(--ink-black, #1A1614);
+}
+
+/* Models breakdown */
+.ledger-models {
+  margin-top: 1rem;
+  padding: 1rem;
+  background: var(--paper-cream, #FAF8F5);
+  border: 1px solid var(--border-light, #E5E0D8);
+}
+
+.ledger-models-label {
+  display: block;
+  margin-bottom: 0.75rem;
+  font-family: var(--font-ui, 'IBM Plex Sans', sans-serif);
+  font-size: 0.625rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ink-gray, #666);
+}
+
+.ledger-models-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.ledger-model-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0;
+  border-bottom: 1px dotted var(--border-light, #E5E0D8);
+}
+
+.ledger-model-item:last-child {
+  border-bottom: none;
+}
+
+.ledger-model-name {
+  font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+  font-size: 0.75rem;
+  color: var(--ink-dark, #2D2926);
+}
+
+.ledger-model-cost {
+  font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--ink-gray, #666);
+}
+
+/* Footer */
+.ledger-footer {
+  padding: 0.75rem 1.25rem;
+  border-top: 2px solid var(--ink-black, #1A1614);
+  background: var(--paper-cream, #FAF8F5);
+}
+
+.ledger-footer-count {
+  font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+  font-size: 0.75rem;
+  color: var(--ink-gray, #666);
+}
+
+/* Empty state */
+.ledger-empty-state {
+  padding: 3rem 2rem;
+  text-align: center;
+}
+
+.ledger-empty-icon {
+  margin-bottom: 1rem;
+}
+
+.ledger-empty-icon svg {
+  width: 48px;
+  height: 48px;
+  color: var(--ink-gray, #999);
+}
+
+.ledger-empty-title {
+  margin: 0 0 0.5rem;
+  font-family: var(--font-display, 'Playfair Display', Georgia, serif);
+  font-size: 1.125rem;
+  font-weight: 600;
+  font-style: italic;
+  color: var(--ink-dark, #2D2926);
+}
+
+.ledger-empty-text {
+  margin: 0;
+  font-family: var(--font-body, 'Source Serif 4', Georgia, serif);
+  font-size: 0.9375rem;
+  color: var(--ink-gray, #666);
+}
+
+/* Loading state */
+.ledger-loading .ledger-row-loading {
+  height: 60px;
+  animation: fadeIn 0.3s ease-out both;
+}
+
+.ledger-loading-line {
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--paper-cream, #FAF8F5) 50%,
+    transparent 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .ledger-header-row {
+    grid-template-columns: 80px 1fr 100px;
+    padding: 0.75rem 1rem;
+    font-size: 0.625rem;
+  }
+
+  .ledger-row-main {
+    grid-template-columns: 80px 1fr 100px;
+    padding: 0.875rem 1rem;
+    gap: 0.75rem;
+  }
+
+  .ledger-date-day {
+    font-size: 0.8125rem;
+  }
+
+  .ledger-desc-text {
+    font-size: 0.875rem;
+  }
+
+  .ledger-amount {
+    font-size: 0.875rem;
+  }
+
+  .ledger-detail-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .ledger-detail-total {
+    grid-column: span 2;
+    margin: -1rem;
+    margin-top: 0;
+    border-left: none;
+    border-top: 1px solid var(--border-light, #E5E0D8);
+  }
+}
+
+@media (max-width: 480px) {
+  .ledger-header-row {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .ledger-header-row .ledger-col-desc {
+    display: none;
+  }
+
+  .ledger-row-main {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .ledger-row-main .ledger-col-desc {
+    display: none;
+  }
+
+  .ledger-detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .ledger-detail-total {
+    grid-column: span 1;
+  }
+}

--- a/frontend/src/components/TransactionLedger.jsx
+++ b/frontend/src/components/TransactionLedger.jsx
@@ -1,0 +1,170 @@
+import { useState } from 'react';
+import './TransactionLedger.css';
+
+function TransactionLedger({ transactions, isLoading }) {
+  const [expandedId, setExpandedId] = useState(null);
+
+  const formatCost = (dollars) => {
+    if (dollars === null || dollars === undefined) return '$0.0000';
+    return `$${parseFloat(dollars).toFixed(4)}`;
+  };
+
+  const formatDate = (dateString) => {
+    const date = new Date(dateString);
+    return {
+      day: date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+      time: date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }),
+      year: date.getFullYear(),
+    };
+  };
+
+  const toggleExpand = (id) => {
+    setExpandedId(expandedId === id ? null : id);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="ledger ledger-loading">
+        <div className="ledger-header-row">
+          <span className="ledger-col-date">Date</span>
+          <span className="ledger-col-desc">Description</span>
+          <span className="ledger-col-amount">Amount</span>
+        </div>
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className="ledger-row ledger-row-loading" style={{ animationDelay: `${i * 0.1}s` }}>
+            <div className="ledger-loading-line" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (!transactions || transactions.length === 0) {
+    return (
+      <div className="ledger ledger-empty">
+        <div className="ledger-header-row">
+          <span className="ledger-col-date">Date</span>
+          <span className="ledger-col-desc">Description</span>
+          <span className="ledger-col-amount">Amount</span>
+        </div>
+        <div className="ledger-empty-state">
+          <div className="ledger-empty-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+              <path d="M9 14l2 2 4-4" />
+            </svg>
+          </div>
+          <p className="ledger-empty-title">No Transactions Yet</p>
+          <p className="ledger-empty-text">
+            Your usage history will appear here after your first inquiry.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="ledger">
+      {/* Ledger header */}
+      <div className="ledger-header-row">
+        <span className="ledger-col-date">Date</span>
+        <span className="ledger-col-desc">Description</span>
+        <span className="ledger-col-amount">Amount</span>
+      </div>
+
+      {/* Ledger entries */}
+      <div className="ledger-body">
+        {transactions.map((tx, index) => {
+          const date = formatDate(tx.created_at);
+          const isExpanded = expandedId === tx.id;
+
+          return (
+            <div
+              key={tx.id}
+              className={`ledger-row ${isExpanded ? 'ledger-row-expanded' : ''}`}
+              style={{ animationDelay: `${index * 0.05}s` }}
+            >
+              <button
+                className="ledger-row-main"
+                onClick={() => toggleExpand(tx.id)}
+                aria-expanded={isExpanded}
+              >
+                <span className="ledger-col-date">
+                  <span className="ledger-date-day">{date.day}</span>
+                  <span className="ledger-date-time">{date.time}</span>
+                </span>
+                <span className="ledger-col-desc">
+                  <span className="ledger-type-badge">Query</span>
+                  <span className="ledger-desc-text">
+                    AI Council Inquiry
+                  </span>
+                </span>
+                <span className="ledger-col-amount">
+                  <span className="ledger-amount negative">
+                    -{formatCost(tx.total_cost)}
+                  </span>
+                  <svg
+                    className={`ledger-expand-icon ${isExpanded ? 'expanded' : ''}`}
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                  >
+                    <polyline points="6 9 12 15 18 9" />
+                  </svg>
+                </span>
+              </button>
+
+              {isExpanded && (
+                <div className="ledger-row-details">
+                  <div className="ledger-detail-grid">
+                    <div className="ledger-detail">
+                      <span className="ledger-detail-label">API Cost</span>
+                      <span className="ledger-detail-value">
+                        {formatCost(tx.openrouter_cost)}
+                      </span>
+                    </div>
+                    <div className="ledger-detail">
+                      <span className="ledger-detail-label">Service Fee (10%)</span>
+                      <span className="ledger-detail-value">
+                        {formatCost(tx.margin_cost)}
+                      </span>
+                    </div>
+                    <div className="ledger-detail ledger-detail-total">
+                      <span className="ledger-detail-label">Total</span>
+                      <span className="ledger-detail-value">
+                        {formatCost(tx.total_cost)}
+                      </span>
+                    </div>
+                  </div>
+                  {tx.model_breakdown && Object.keys(tx.model_breakdown).length > 0 && (
+                    <div className="ledger-models">
+                      <span className="ledger-models-label">Models Used</span>
+                      <div className="ledger-models-list">
+                        {Object.entries(tx.model_breakdown).map(([model, cost]) => (
+                          <div key={model} className="ledger-model-item">
+                            <span className="ledger-model-name">{model}</span>
+                            <span className="ledger-model-cost">{formatCost(cost)}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Ledger footer */}
+      <div className="ledger-footer">
+        <span className="ledger-footer-count">
+          {transactions.length} transaction{transactions.length !== 1 ? 's' : ''}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export default TransactionLedger;


### PR DESCRIPTION
## Summary
- Replace Settings modal with dedicated Account page at `/account`
- Add "Financial Gazette" editorial styling following "Paper of Record" design system
- Implement BalanceCard with stock certificate aesthetic
- Implement TransactionLedger with Victorian banking ledger style

## New Components
- `Account.jsx` / `Account.css` - Main account page with two-column layout
- `BalanceCard.jsx` / `BalanceCard.css` - Balance display with ornate corners
- `TransactionLedger.jsx` / `TransactionLedger.css` - Usage history with expandable details

## Changes
- `AvatarMenu.jsx` - Links to /account instead of opening Settings modal
- `ChatInterface.jsx` - Balance click navigates to /account
- `App.jsx` - Added /account route, removed Settings modal

## Design Features
- Two-column broadsheet layout (responsive stacking on mobile)
- Decorative corner flourishes and typographic ornaments
- Playfair Display for headers, IBM Plex Mono for monetary values
- Expandable transaction rows with cost breakdown details
- Member info section with OAuth provider display
- Staggered animation reveals on page load

## Test plan
- [x] Frontend builds successfully
- [ ] Navigate to /account from avatar menu
- [ ] Click balance indicator to go to /account
- [ ] Verify balance card displays correctly
- [ ] Verify deposit options work
- [ ] Verify transaction ledger expands/collapses
- [ ] Verify responsive layout on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)